### PR TITLE
Added parameter for enabling/disabling public IP on server instances.

### DIFF
--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -31,6 +31,13 @@ Parameters:
   ChefServerSubnets:
     Description: Provide a list of Subnet IDs for the Chef Servers
     Type: List<AWS::EC2::Subnet::Id>
+  ChefServerAssociatePublicIpAddress:
+    Description: Assign public IP addresses to the Chef Servers or not
+    Type: String
+    Default: true
+    AllowedValues:
+    - 'true'
+    - 'false'
   DBPassword:
     Description: Enter DB Password
     NoEcho: true
@@ -378,7 +385,7 @@ Resources:
   ServerLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      AssociatePublicIpAddress: true
+      AssociatePublicIpAddress: !Ref ChefServerAssociatePublicIpAddress
       EbsOptimized: true
       BlockDeviceMappings:
       - DeviceName: /dev/xvda

--- a/stack_parameters.json.example
+++ b/stack_parameters.json.example
@@ -40,6 +40,10 @@
     "ParameterValue": "subnet-66c62b01,subnet-df1611a9,subnet-01473659"
   },
   {
+    "ParameterKey":   "ChefServerAssociatePublicIpAddress",
+    "ParameterValue": "true"
+  },
+  {
     "ParameterKey":   "InstanceType",
     "ParameterValue": "c4.large"
   },


### PR DESCRIPTION
This retains the previous behaviour of associating public IP addresses with the Chef Server EC2 instances by default.
