### PR TITLE
Moving aws-signing-proxy config out of upstart

### DIFF
--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -473,14 +473,19 @@ Resources:
                 opscode_expander['enable'] = false
                 dark_launch['actions'] = false
             /usr/local/bin/aws-signing-proxy:
-              source: https://github.com/nsdavidson/aws-signing-proxy/releases/download/v0.1.2/aws-signing-proxy
+              source: https://github.com/nsdavidson/aws-signing-proxy/releases/download/v0.2.0/aws-signing-proxy
               mode: '000755'
             /etc/init/aws-signing-proxy.conf:
               content: !Sub |
                 start on runlevel [2345]
                 stop on shutdown
                 respawn
-                exec /usr/local/bin/aws-signing-proxy -target https://${ElasticsearchDomain.DomainEndpoint} -port 9200 -listen-address 127.0.0.1 >> /var/log/aws-signing-proxy.log 2>&1
+                exec /usr/local/bin/aws-signing-proxy >> /var/log/aws-signing-proxy.log 2>&1
+            /etc/aws-signing-proxy.yml:
+              content: !Sub |
+                listen-address: 127.0.0.1
+                port: 9200
+                target: https://${ElasticsearchDomain.DomainEndpoint}
           commands:
             01_start_es_proxy:
               command: initctl start aws-signing-proxy


### PR DESCRIPTION
Using a new version of aws-signing-proxy that can use a config file.
Moved config out of Upstart file in and into separate file.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>