### PR TITLE
Moving push jobs config

### DIFF
--- a/files/main.sh
+++ b/files/main.sh
@@ -82,9 +82,8 @@ fi
 
 # the bootstrap instance should sync files after reconfigure, regardless if configs exist or not (upgrades)
 if [ -n "${BOOTSTRAP_TAGS}" ]; then
+  echo "[INFO] Configuring push jobs"
+  push_jobs_configure
   echo "[INFO] syncing bootstrap secrets up to S3"
   upload_config
 fi
-
-echo "[INFO] Configuring push jobs"
-push_jobs_configure


### PR DESCRIPTION
This fixes a bug where the push jobs secrets weren't being pushed to S3, thus causing a new Push SSL cert to be created upon each rebuild

Signed-off-by: Nolan Davidson <ndavidson@chef.io>