### PR TITLE
3.0 Release & Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ addons:
     - awscli
 install: true
 script:
-- aws cloudformation validate-template --template-body file://backendless_chef.yaml
+- aws s3 cp backendless_chef.yaml s3://aws-native-chef-server/backendless_chef_test.yaml
+- aws cloudformation validate-template --template-url https://s3.amazonaws.com/aws-native-chef-server/backendless_chef_test.yaml
 deploy:
   provider: s3
   access_key_id:

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ You can launch this stack with the push of a button:
 However, the most repeatable and least error-prone way to launch this stack is to use the `aws` command-line. First copy file `stack_parameters.json.example` to `stack_parameters.json`, make the necessary changes, then run this command:
 
 ```bash
+MYBUCKET=aws-native-chef-server
 aws cloudformation create-stack \
   --stack-name irving-backendless-chef \
-  --template-body file://backendless_chef.yaml \
+  --template-url https://s3.amazonaws.com/$MYBUCKET/backendless_chef.yaml \
   --capabilities CAPABILITY_IAM \
   --on-failure DO_NOTHING \
   --parameters file://stack_parameters.json
@@ -43,10 +44,12 @@ aws cloudformation create-stack \
 If you've made changes to the template content or parameters and you wish to update a running stack:
 
 ```bash
-aws cloudformation validate-template --template-body file://backendless_chef.yaml &&
+MYBUCKET=aws-native-chef-server
+aws s3 cp backendless_chef.yaml s3://$MYBUCKET/
+aws cloudformation validate-template --template-url https://s3.amazonaws.com/$MYBUCKET/backendless_chef.yaml
 aws cloudformation update-stack \
-  --stack-name irving-backendless-chef \
-  --template-body file://backendless_chef.yaml \
+  --stack-name irving-backendless-chef2 \
+  --template-url https://s3.amazonaws.com/$MYBUCKET/backendless_chef.yaml \
   --capabilities CAPABILITY_IAM \
   --parameters file://stack_parameters.json
 ```

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -2,6 +2,77 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: AWS Native Chef Server v3.0.0
 
 Parameters:
+  # Required Parameters
+  VPC:
+    Description: Choose VPC to use
+    Type: AWS::EC2::VPC::Id
+  ChefServerSubnets:
+    Description: Provide a list of Subnet IDs for the Chef Servers (must be within the specified VPC)
+    Type: List<AWS::EC2::Subnet::Id>
+  SSLCertificateARN:
+    Default: 'arn:aws:iam::'
+    Description: SSL Certficate ARN for SSL Certficate
+    Type: String
+  SSHSecurityGroup:
+    Description: Select Security Group for SSH Access (must be within the specified VPC)
+    Type: AWS::EC2::SecurityGroup::Id
+  KeyName:
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
+    Type: AWS::EC2::KeyPair::KeyName
+  DBPassword:
+    Description: Enter DB Password
+    NoEcho: true
+    Type: String
+  ContactEmail:
+    Description: Contact email for Cloudwatch notifications and instance tagging
+    Type: String
+  ContactDept:
+    Description: Contact department for billing purposes
+    Type: String
+  ###############################################################################
+  # Performance Settings
+  InstanceType:
+    ConstraintDescription: must be a valid EC2 instance type.
+    Default: c4.large
+    Type: String
+  MaxFrontendInstances:
+    Description: The maximum number of additional frontend instances to launch
+    Type: Number
+    Default: 3
+  LicenseCount:
+    Default: '25'
+    Description: Enter how many licenses you have purchased
+    Type: String
+  DBInstanceClass:
+    Description: Storage size allocated for the database
+    Default: 'db.m4.large'
+    Type: String
+  DBAllocatedStorage:
+    Description: Storage size allocated for the database
+    Default: '100'
+    Type: String
+  DBIops:
+    Description: IOPS allocated to the storage (storage size * 10)
+    Default: '1000'
+    Type: String
+  ElasticSearchVersion:
+    Description: Version of ElasticSearch to use. Chef 12.16 supports v2.3 or 5.3. (5.3 recommended for new installs)
+    Type: String
+    Default: '5.5'
+    AllowedValues:
+    - '2.3'
+    - '5.3'
+    - '5.5'
+  ElasticSearchShardCount:
+    Description: Number of ElasticSearch hosts to provision at launch (3 recommended)
+    Default: 3
+    Type: Number
+  ElasticSearchReplicaCount:
+    Description: Replication factor for ElasticSearch shards (how many extra copies to keep)
+    Default: 2
+    Type: Number
+  ###############################################################################
+  # Package Versions & Locations
   ChefServerPackage:
     Description: The URL to the chef server EL7 (chef-server-core) package which will be downloaded
     Type: String
@@ -18,10 +89,8 @@ Parameters:
     Description: The base URL for script and config files needed by this template (include a trailing /)
     Type: String
     Default: 'https://raw.githubusercontent.com/chef-customers/aws_native_chef_server/master/files/'
-  MaxFrontendInstances:
-    Description: The maximum number of additional frontend instances to launch
-    Type: Number
-    Default: 3
+  ###############################################################################
+  # Security Settings
   LoadBalancerScheme:
     Description: Network Scheme for the ELB
     Type: String
@@ -29,9 +98,6 @@ Parameters:
     AllowedValues:
     - 'internet-facing'
     - 'internal'
-  ChefServerSubnets:
-    Description: Provide a list of Subnet IDs for the Chef Servers
-    Type: List<AWS::EC2::Subnet::Id>
   ChefServerAssociatePublicIpAddress:
     Description: Assign public IP addresses to the Chef Servers or not
     Type: String
@@ -39,71 +105,6 @@ Parameters:
     AllowedValues:
     - 'true'
     - 'false'
-  DBPassword:
-    Description: Enter DB Password
-    NoEcho: true
-    Type: String
-  DBPort:
-    Default: '5432'
-    Description: Enter DB Port
-    Type: String
-  DBUser:
-    Description: Enter DB User Name
-    Default: 'chefadmin'
-    Type: String
-  DBName:
-    Description: Enter DB Name
-    Default: 'chef'
-    Type: String
-  DBAllocatedStorage:
-    Description: Storage size allocated for the database
-    Default: '100'
-    Type: String
-  DBIops:
-    Description: IOPS allocated to the storage (storage size * 10)
-    Default: '1000'
-    Type: String
-  DBInstanceClass:
-    Description: Storage size allocated for the database
-    Default: 'db.m4.large'
-    Type: String
-  ElasticSearchVersion:
-    Description: Version of ElasticSearch to use. Chef 12.16 supports v2.3 or 5.3. (5.3 recommended for new installs)
-    Type: String
-    Default: '2.3'
-    AllowedValues:
-    - '2.3'
-    - '5.3'
-    - '5.5'
-  ElasticSearchShardCount:
-    Description: Number of ElasticSearch hosts to provision at launch (3 recommended)
-    Default: 3
-    Type: Number
-  ElasticSearchReplicaCount:
-    Description: Replication factor for ElasticSearch shards (how many extra copies to keep)
-    Default: 2
-    Type: Number
-  InstanceType:
-    ConstraintDescription: must be a valid EC2 instance type.
-    Default: c4.large
-    Type: String
-  KeyName:
-    Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
-    Type: AWS::EC2::KeyPair::KeyName
-  LicenseCount:
-    Default: '25'
-    Description: Enter how many licenses you have purchased
-    Type: String
-  SSHSecurityGroup:
-    Description: Select Security Group for SSH Access
-    Type: AWS::EC2::SecurityGroup::Id
-  SSLCertificateARN:
-    Default: 'arn:aws:iam::'
-    Description: SSL Certficate ARN for SSL Certficate
-    Type: String
-  VPC:
-    Description: Choose VPC to use
-    Type: AWS::EC2::VPC::Id
   DisableSignup:
     AllowedValues:
     - 'true'
@@ -119,16 +120,54 @@ Parameters:
     Description: Supply an S3 Bucket name for the Chef Servers to read/write config files to (leave blank to have it created for you)
     Type: String
     Default: ''
-  ContactDept:
-    Description: Contact department for billing purposes
-    Type: String
-  ContactEmail:
-    Description: Contact email for Cloudwatch notifications and instance tagging
-    Type: String
+  ###############################################################################
+  # Other Settings
   ChefDefaultOrgName:
     Default: ''
     Description: Default Chef organization name (typically only used when migrating from Chef Server 11, otherwise leave blank)
     Type: String
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Required Parameters"
+        Parameters:
+          - VPC
+          - ChefServerSubnets
+          - SSLCertificateARN
+          - SSHSecurityGroup
+          - KeyName
+          - DBPassword
+          - ContactEmail
+          - ContactDept
+      - Label:
+          default: "Performance Settings"
+        Parameters:
+          - InstanceType
+          - MaxFrontendInstances
+          - LicenseCount
+          - DBInstanceClass
+          - DBAllocatedStorage
+          - DBIops
+          - ElasticSearchVersion
+          - ElasticSearchShardCount
+          - ElasticSearchReplicaCount
+      - Label:
+          default: "Package Versions & Locations"
+        Parameters:
+          - ChefServerPackage
+          - ChefManagePackage
+          - PushJobsPackage
+          - FilesLocation
+      - Label:
+          default: "Security Settings"
+        Parameters:
+          - LoadBalancerScheme
+          - ChefServerAssociatePublicIpAddress
+          - DisableSignup
+          - ChefServerIamRole
+          - ChefSecretsBucket
 
 Conditions:
   CreateChefServerIamRole:
@@ -137,6 +176,10 @@ Conditions:
     !Equals [ !Ref ChefSecretsBucket, '' ]
 
 # Should be the latest Amazon Linux AMI from: https://aws.amazon.com/amazon-linux-ami/
+# NOTE: If you wish to replace this AMI with your own RHEL-ish variety, be prepared to
+# - have the `aws` & `cfn-init` tools preinstalled
+# - Install and enable NTP
+# - Support upstart as the init system, or else rewrite the below aws-signing-proxy service defitinion into systemd
 Mappings:
   AWSRegion2AMI:
     us-east-1:
@@ -526,7 +569,7 @@ Resources:
                 license['nodes'] = ${LicenseCount}
                 postgresql['external'] = true
                 postgresql['vip'] = '${DBPostgres.Endpoint.Address}'
-                postgresql['db_superuser'] = '${DBUser}'
+                postgresql['db_superuser'] = 'chefadmin'
                 postgresql['db_superuser_password'] = '${DBPassword}'
                 oc_chef_authz['http_init_count'] = 100
                 oc_chef_authz['http_queue_max'] = 200
@@ -616,8 +659,8 @@ Resources:
       VpcId: !Ref VPC
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: !Ref DBPort
-          ToPort: !Ref DBPort
+          FromPort: 5432
+          ToPort: 5432
           SourceSecurityGroupId: !Ref FrontendSecurityGroup
 
   DBSubnetGroup:
@@ -630,10 +673,10 @@ Resources:
     Type: AWS::RDS::DBInstance
     DeletionPolicy: "Snapshot"
     Properties:
-      DBName: !Ref DBName
+      DBName: chef
       AllocatedStorage: !Ref DBAllocatedStorage
       Iops: !Ref DBIops
-      MasterUsername: !Ref DBUser
+      MasterUsername: chefadmin
       MasterUserPassword: !Ref DBPassword
       DBInstanceClass: !Ref DBInstanceClass
       StorageType: io1

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -68,7 +68,7 @@ Parameters:
     Default: 3
     Type: Number
   ElasticSearchReplicaCount:
-    Description: Replication factor for ElasticSearch shards (how many extra copies to keep)
+    Description: Replication factor for ElasticSearch sha vrds (how many extra copies to keep)
     Default: 2
     Type: Number
   ###############################################################################
@@ -93,6 +93,10 @@ Parameters:
     Description: The S3 bucket location of the script which runs after the Main script
     Type: String
     Default: ''
+  LocalScriptLocation:
+    Description: The local path to download setup scripts to
+    Type: String
+    Default: '/tmp'
   ###############################################################################
   # Security Settings
   LoadBalancerScheme:
@@ -106,10 +110,9 @@ Parameters:
     Description: Supply a security group for your load balancer (leave blank to have it created for you). Using the default security group is recommended.
     Type: String
     Default: ''
-  FrontendSecurityGroupId:
+  FrontendSecurityGroupIds:
     Description: Supply a security group for your chef frontends (leave blank to have it created for you). Using the default security group is recommended.
     Type: String
-    Default: ''
   ChefServerAssociatePublicIpAddress:
     Description: Assign public IP addresses to the Chef Servers or not
     Type: String
@@ -201,7 +204,7 @@ Conditions:
   CreateLoadBalancerSecurityGroup:
     !Equals [ !Ref LoadBalancerSecurityGroupId, '' ]
   CreateFrontendSecurityGroup:
-    !Equals [ !Ref FrontendSecurityGroupId, '' ]
+    !Equals [ !Ref FrontendSecurityGroupIds, '' ]
 
 # Should be the latest Amazon Linux AMI from: https://aws.amazon.com/amazon-linux-ami/
 # NOTE: If you wish to replace this AMI with your own RHEL-ish variety, be prepared to
@@ -556,7 +559,7 @@ Resources:
       SecurityGroups:
       - !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
       - !Ref SSHSecurityGroup
-      - !If [CreateFrontendSecurityGroup, !Ref FrontendSecurityGroup, !Ref FrontendSecurityGroupId]
+      - !If [CreateFrontendSecurityGroup, !Ref FrontendSecurityGroup, !Ref FrontendSecurityGroupIds]
       UserData:
         "Fn::Base64": !Sub |
           #!/bin/bash -x
@@ -659,8 +662,8 @@ Resources:
             02_before_script:
               command: !Sub |
                 if [ -n '${BeforeScriptLocation}' ]; then
-                    aws s3 cp ${BeforeScriptLocation} /tmp/before.sh
-                    bash -x /tmp/before.sh
+                    aws s3 cp ${BeforeScriptLocation} ${LocalScriptLocation}/before.sh
+                    bash -x ${LocalScriptLocation}/before.sh
                 fi
                 if [ -n '${ChefServerCustomConfig}' ]; then
                     aws s3 cp ${ChefServerCustomConfig} /etc/opscode/chef-server-custom.rb
@@ -675,14 +678,14 @@ Resources:
                 export AWS_REGION=${AWS::Region}
                 export WAITHANDLE="${WaitHandle}"
                 # don't sign the request as a workaround to download object from a third party public bucket
-                aws s3 cp --no-sign-request s3://aws-native-chef-server/files/main.sh /tmp/main.sh
-                bash -x /tmp/main.sh
+                aws s3 cp --no-sign-request s3://aws-native-chef-server/files/main.sh ${LocalScriptLocation}/main.sh
+                bash -x ${LocalScriptLocation}/main.sh
               - { S3BUCKET: !If [CreateChefSecretsBucket, !Ref ChefBucket, !Ref ChefSecretsBucket] }
             04_after_script:
               command: !Sub |
                 if [ -n '${AfterScriptLocation}' ]; then
-                  aws s3 cp ${AfterScriptLocation} /tmp/after.sh
-                  bash -x /tmp/after.sh
+                  aws s3 cp ${AfterScriptLocation} ${LocalScriptLocation}/after.sh
+                  bash -x ${LocalScriptLocation}/after.sh
                 fi
             05_configure_cloudwatch_monitoring:
               command: !Sub |

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -88,7 +88,7 @@ Parameters:
   BeforeScriptLocation:
     Description: The S3 bucket location of the script which runs before the Main script
     Type: String
-    Default: '' 
+    Default: ''
   AfterScriptLocation:
     Description: The S3 bucket location of the script which runs after the Main script
     Type: String
@@ -556,6 +556,7 @@ Resources:
       SecurityGroups:
       - !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
       - !Ref SSHSecurityGroup
+      - !If [CreateFrontendSecurityGroup, !Ref FrontendSecurityGroup, !Ref FrontendSecurityGroupId]
       UserData:
         "Fn::Base64": !Sub |
           #!/bin/bash -x

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -633,7 +633,7 @@ Resources:
                 dark_launch['actions'] = false
                 default_orgname '${ChefDefaultOrgName}'.empty? ? null : '${ChefDefaultOrgName}'
                 # special handling for Chef Automate URL and Token which might be empty strings
-                unless '${ChefAutomateServerUrl}'.empty? && ! '${ChefAutomateToken}'.empty?
+                unless '${ChefAutomateServerUrl}'.empty? || '${ChefAutomateToken}'.empty?
                   data_collector['root_url'] = '${ChefAutomateServerUrl}'
                   data_collector['token'] = '${ChefAutomateToken}'
                 end

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -93,10 +93,6 @@ Parameters:
     Description: The S3 bucket location of the script which runs after the Main script
     Type: String
     Default: ''
-  LocalScriptLocation:
-    Description: The local path to download setup scripts to
-    Type: String
-    Default: '/tmp'
   ###############################################################################
   # Security Settings
   LoadBalancerScheme:
@@ -662,8 +658,8 @@ Resources:
             02_before_script:
               command: !Sub |
                 if [ -n '${BeforeScriptLocation}' ]; then
-                    aws s3 cp ${BeforeScriptLocation} ${LocalScriptLocation}/before.sh
-                    bash -x ${LocalScriptLocation}/before.sh
+                    aws s3 cp ${BeforeScriptLocation} /root/before.sh
+                    bash -x /root/before.sh
                 fi
                 if [ -n '${ChefServerCustomConfig}' ]; then
                     aws s3 cp ${ChefServerCustomConfig} /etc/opscode/chef-server-custom.rb
@@ -678,14 +674,14 @@ Resources:
                 export AWS_REGION=${AWS::Region}
                 export WAITHANDLE="${WaitHandle}"
                 # don't sign the request as a workaround to download object from a third party public bucket
-                aws s3 cp --no-sign-request s3://aws-native-chef-server/files/main.sh ${LocalScriptLocation}/main.sh
-                bash -x ${LocalScriptLocation}/main.sh
+                aws s3 cp --no-sign-request s3://aws-native-chef-server/files/main.sh /root/main.sh
+                bash -x /root/main.sh
               - { S3BUCKET: !If [CreateChefSecretsBucket, !Ref ChefBucket, !Ref ChefSecretsBucket] }
             04_after_script:
               command: !Sub |
                 if [ -n '${AfterScriptLocation}' ]; then
-                  aws s3 cp ${AfterScriptLocation} ${LocalScriptLocation}/after.sh
-                  bash -x ${LocalScriptLocation}/after.sh
+                  aws s3 cp ${AfterScriptLocation} /root/after.sh
+                  bash -x /root/after.sh
                 fi
             05_configure_cloudwatch_monitoring:
               command: !Sub |

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -626,7 +626,7 @@ Resources:
                   data_collector['token'] = '${ChefAutomateToken}'
                 end
             /usr/local/bin/aws-signing-proxy:
-              source: https://github.com/nsdavidson/aws-signing-proxy/releases/download/v0.3.0/aws-signing-proxy
+              source: https://github.com/chef-customers/aws-signing-proxy/releases/download/v0.3.0/aws-signing-proxy
               mode: '000755'
             /etc/init/aws-signing-proxy.conf:
               content: !Sub |

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -106,6 +106,10 @@ Parameters:
     Description: Supply a security group for your load balancer (leave blank to have it created for you). Using the default security group is recommended.
     Type: String
     Default: ''
+  FrontendSecurityGroupId:
+    Description: Supply a security group for your chef frontends (leave blank to have it created for you). Using the default security group is recommended.
+    Type: String
+    Default: ''
   ChefServerAssociatePublicIpAddress:
     Description: Assign public IP addresses to the Chef Servers or not
     Type: String
@@ -196,6 +200,8 @@ Conditions:
     !Equals [ !Ref ChefSecretsBucket, '' ]
   CreateLoadBalancerSecurityGroup:
     !Equals [ !Ref LoadBalancerSecurityGroupId, '' ]
+  CreateFrontendSecurityGroup:
+    !Equals [ !Ref FrontendSecurityGroupId, '' ]
 
 # Should be the latest Amazon Linux AMI from: https://aws.amazon.com/amazon-linux-ami/
 # NOTE: If you wish to replace this AMI with your own RHEL-ish variety, be prepared to
@@ -358,6 +364,7 @@ Resources:
 
   FrontendSecurityGroup:
     Type: AWS::EC2::SecurityGroup
+    Condition: CreateFrontendSecurityGroup
     Properties:
       GroupDescription: Setup Ingress/Egress for Chef Frontend
       SecurityGroupEgress:
@@ -547,7 +554,7 @@ Resources:
       InstanceType: !Ref InstanceType
       KeyName: !Ref KeyName
       SecurityGroups:
-      - !Ref FrontendSecurityGroup
+      - !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
       - !Ref SSHSecurityGroup
       UserData:
         "Fn::Base64": !Sub |
@@ -707,7 +714,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: 5432
           ToPort: 5432
-          SourceSecurityGroupId: !Ref FrontendSecurityGroup
+          SourceSecurityGroupId: !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
 
   DBSubnetGroup:
     Type: AWS::RDS::DBSubnetGroup

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -130,6 +130,14 @@ Parameters:
     Default: ''
   ###############################################################################
   # Other Settings
+  ChefAutomateServerUrl:
+    Description: The URL of the Chef Automate Server, for forwarding Visibility data.  Leave blank to disable.
+    Type: String
+    Default: ''
+  ChefAutomateToken:
+    Description: The secret token used to communicate with the Chef Automate Server, for forwarding Visibility data.  Leave blank to disable.
+    Type: String
+    Default: ''
   ChefDefaultOrgName:
     Default: ''
     Description: Default Chef organization name (typically only used when migrating from Chef Server 11, otherwise leave blank)
@@ -612,6 +620,11 @@ Resources:
                 opscode_expander['enable'] = false
                 dark_launch['actions'] = false
                 default_orgname '${ChefDefaultOrgName}'.empty? ? null : '${ChefDefaultOrgName}'
+                # special handling for Chef Automate URL and Token which might be empty strings
+                unless '${ChefAutomateServerUrl}'.empty? && ! '${ChefAutomateToken}'.empty?
+                  data_collector['root_url'] = '${ChefAutomateServerUrl}'
+                  data_collector['token'] = '${ChefAutomateToken}'
+                end
             /usr/local/bin/aws-signing-proxy:
               source: https://github.com/nsdavidson/aws-signing-proxy/releases/download/v0.3.0/aws-signing-proxy
               mode: '000755'

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -85,10 +85,6 @@ Parameters:
     Description: The URL to the push jobs server package which will be downloaded
     Type: String
     Default: 'https://packages.chef.io/files/stable/opscode-push-jobs-server/2.2.6/el/7/opscode-push-jobs-server-2.2.6-1.el7.x86_64.rpm'
-  MainScriptLocation:
-    Description: The S3 bucket location of the main script which configures Chef Server
-    Type: String
-    Default: s3://aws-native-chef-server/files/main.sh
   BeforeScriptLocation:
     Description: The S3 bucket location of the script which runs before the Main script
     Type: String
@@ -182,7 +178,6 @@ Metadata:
           - ChefServerPackage
           - ChefManagePackage
           - PushJobsPackage
-          - MainScriptLocation
           - BeforeScriptLocation
           - AfterScriptLocation
       - Label:
@@ -671,7 +666,8 @@ Resources:
                 export BUCKET=${S3BUCKET}
                 export AWS_REGION=${AWS::Region}
                 export WAITHANDLE="${WaitHandle}"
-                aws s3 cp ${MainScriptLocation} /tmp/main.sh
+                # don't sign the request as a workaround to download object from a third party public bucket
+                aws s3 cp --no-sign-request s3://aws-native-chef-server/files/main.sh /tmp/main.sh
                 bash -x /tmp/main.sh
               - { S3BUCKET: !If [CreateChefSecretsBucket, !Ref ChefBucket, !Ref ChefSecretsBucket] }
             04_after_script:

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -85,10 +85,18 @@ Parameters:
     Description: The URL to the push jobs server package which will be downloaded
     Type: String
     Default: 'https://packages.chef.io/files/stable/opscode-push-jobs-server/2.2.6/el/7/opscode-push-jobs-server-2.2.6-1.el7.x86_64.rpm'
-  FilesLocation:
-    Description: The base URL for script and config files needed by this template (include a trailing /)
+  MainScriptLocation:
+    Description: The S3 bucket location of the main script which configures Chef Server
     Type: String
-    Default: 'https://raw.githubusercontent.com/chef-customers/aws_native_chef_server/master/files/'
+    Default: s3://aws-native-chef-server/files/main.sh
+  BeforeScriptLocation:
+    Description: The S3 bucket location of the script which runs before the Main script
+    Type: String
+    Default: s3://aws-native-chef-server/files/before.sh
+  AfterScriptLocation:
+    Description: The S3 bucket location of the script which runs after the Main script
+    Type: String
+    Default: s3://aws-native-chef-server/files/after.sh
   ###############################################################################
   # Security Settings
   LoadBalancerScheme:
@@ -159,7 +167,9 @@ Metadata:
           - ChefServerPackage
           - ChefManagePackage
           - PushJobsPackage
-          - FilesLocation
+          - MainScriptLocation
+          - BeforeScriptLocation
+          - AfterScriptLocation
       - Label:
           default: "Security Settings"
         Parameters:
@@ -620,17 +630,25 @@ Resources:
           commands:
             01_start_es_proxy:
               command: initctl start aws-signing-proxy
-            02_configure_chef_server:
+            02_before_script:
+              command: !Sub |
+                aws s3 cp ${BeforeScriptLocation} /tmp/before.sh
+                bash -x /tmp/before.sh
+            03_configure_chef_server:
               command: !Sub
               - |
                 export STACKNAME=${AWS::StackName}
                 export BUCKET=${S3BUCKET}
                 export AWS_REGION=${AWS::Region}
                 export WAITHANDLE="${WaitHandle}"
-                curl -s ${FilesLocation}main.sh | bash -x
+                aws s3 cp ${MainScriptLocation} /tmp/main.sh
+                bash -x /tmp/main.sh
               - { S3BUCKET: !If [CreateChefSecretsBucket, !Ref ChefBucket, !Ref ChefSecretsBucket] }
-
-            03_configure_cloudwatch_monitoring:
+            04_after_script:
+              command: !Sub |
+                aws s3 cp ${AfterScriptLocation} /tmp/after.sh
+                bash -x /tmp/after.sh
+            05_configure_cloudwatch_monitoring:
               command: !Sub |
                 mkdir /opt/cloudwatch_monitoring
                 cd /opt/cloudwatch_monitoring

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -90,11 +90,11 @@ Parameters:
     Type: String
     Default: 'https://packages.chef.io/files/stable/opscode-push-jobs-server/2.2.6/el/7/opscode-push-jobs-server-2.2.6-1.el7.x86_64.rpm'
   BeforeScriptLocation:
-    Description: The S3 bucket location of the script which runs before the Main script
+    Description: The S3 location of the script which runs before the Main script
     Type: String
     Default: ''
   AfterScriptLocation:
-    Description: The S3 bucket location of the script which runs after the Main script
+    Description: The S3 location of the script which runs after the Main script
     Type: String
     Default: ''
   ###############################################################################
@@ -153,6 +153,15 @@ Parameters:
   ChefServerCustomConfig:
     Default: ''
     Type: String
+    Description: The S3 location of a custom chef-server configuration snippet that will be injected into the chef-server.rb
+  Route53HostedZone:
+    Type: String
+    Default: ''
+    Description: Optionally supply a Route 53 Hosted Zone name (eg. mydomain.com.) for auto-creating a DNS record (Leave blank to disable)
+  Route53RecordName:
+    Type: String
+    Default: 'chef'
+    Description: Supply a DNS record name that will be prepended to the Route 53 Hosted Zone
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -209,8 +218,9 @@ Conditions:
     !Equals [ !Ref LoadBalancerSecurityGroupId, '' ]
   CreateFrontendSecurityGroup:
     !Equals [ !Ref FrontendSecurityGroupId, '' ]
+  CreateRoute53Record:
+    !Not [!Equals [ !Ref Route53HostedZone, '' ] ]
 
-# Should be the latest Amazon Linux AMI from: https://aws.amazon.com/amazon-linux-ami/
 # NOTE: If you wish to replace this AMI with your own RHEL-ish variety, be prepared to
 # - have the `aws` & `cfn-init` tools preinstalled
 # - Install and enable NTP
@@ -227,7 +237,6 @@ Mappings:
       AMI: ami-e689729e
 
 Resources:
-#########################################################################################
 # Frontend Autoscale Groups
 #########################################################################################
 # The first chef server we launch is the 'bootstrap' which needs to come up first and set schema before the rest
@@ -705,7 +714,6 @@ Resources:
   WaitHandle:
     Type: AWS::CloudFormation::WaitConditionHandle
 
-#########################################################################################
 # PostgreSQL DB
 #########################################################################################
   DBSecurityGroup:
@@ -754,7 +762,6 @@ Resources:
         - Key: X-Contact
           Value: !Ref ContactEmail
 
-#########################################################################################
 # ElasticSearch
 #########################################################################################
   ElasticsearchDomain:
@@ -766,13 +773,6 @@ Resources:
         ZoneAwarenessEnabled: false
         InstanceType: m3.large.elasticsearch
         DedicatedMasterEnabled: false
-        # DedicatedMasterType: t2.medium.elasticsearch
-        # DedicatedMasterCount: "3"
-      # EBSOptions:
-      #   EBSEnabled: true
-      #   Iops: !Ref DBIops
-      #   VolumeSize: !Ref DBAllocatedStorage
-      #   VolumeType: io1
       SnapshotOptions:
         AutomatedSnapshotStartHour: "0"
       AccessPolicies:
@@ -792,8 +792,20 @@ Resources:
       - Key: X-Contact
         Value: !Ref ContactEmail
 
-
+# Route 53 Record
 #########################################################################################
+  ChefLBDNSRecord:
+    Type: AWS::Route53::RecordSet
+    Condition: CreateRoute53Record
+    Properties:
+      HostedZoneName: !Ref Route53HostedZone
+      Comment: !Sub Created by Cloudformation ${AWS::StackName}
+      Name: !Sub ${Route53RecordName}.${Route53HostedZone}
+      Type: CNAME
+      TTL: 900
+      ResourceRecords:
+      - !GetAtt ChefALB.DNSName
+
 # Monitoring
 #########################################################################################
   AlertNotificationTopic:

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -39,6 +39,10 @@ Parameters:
     Description: The maximum number of additional frontend instances to launch
     Type: Number
     Default: 3
+  MinFrontendInstances:
+    Description: The minimum number of frontend instances to launch in addition to the Bootstrap Frontend
+    Type: Number
+    Default: 1
   LicenseCount:
     Default: '25'
     Description: Enter how many licenses you have purchased
@@ -168,6 +172,7 @@ Metadata:
         Parameters:
           - InstanceType
           - MaxFrontendInstances
+          - MinFrontendInstances
           - LicenseCount
           - DBInstanceClass
           - DBAllocatedStorage
@@ -260,7 +265,7 @@ Resources:
       TargetGroupARNs:
       - !Ref ChefTargetGroup
       MaxSize: !Sub '${MaxFrontendInstances}'
-      MinSize: '1'
+      MinSize: !Sub '${MinFrontendInstances}'
       Tags:
       - Key: Name
         Value: !Sub ${AWS::StackName}-frontend

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -13,8 +13,8 @@ Parameters:
     Default: 'arn:aws:iam::'
     Description: SSL Certficate ARN for SSL Certficate
     Type: String
-  SSHSecurityGroup:
-    Description: Select Security Group for SSH Access (must be within the specified VPC)
+  InboundAdminSecurityGroup:
+    Description: Select an existing Security Group in your VPC to define administrative ACLs (SSH, monitoring tools, etc) to the Chef servers
     Type: AWS::EC2::SecurityGroup::Id
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
@@ -110,9 +110,10 @@ Parameters:
     Description: Supply a security group for your load balancer (leave blank to have it created for you). Using the default security group is recommended.
     Type: String
     Default: ''
-  FrontendSecurityGroupIds:
+  FrontendSecurityGroupId:
     Description: Supply a security group for your chef frontends (leave blank to have it created for you). Using the default security group is recommended.
     Type: String
+    Default: ''
   ChefServerAssociatePublicIpAddress:
     Description: Assign public IP addresses to the Chef Servers or not
     Type: String
@@ -162,7 +163,7 @@ Metadata:
           - VPC
           - ChefServerSubnets
           - SSLCertificateARN
-          - SSHSecurityGroup
+          - InboundAdminSecurityGroup
           - KeyName
           - DBPassword
           - ContactEmail
@@ -192,6 +193,8 @@ Metadata:
           default: "Security Settings"
         Parameters:
           - LoadBalancerScheme
+          - LoadBalancerSecurityGroupId
+          - FrontendSecurityGroupId
           - ChefServerAssociatePublicIpAddress
           - DisableSignup
           - ChefServerIamRole
@@ -205,7 +208,7 @@ Conditions:
   CreateLoadBalancerSecurityGroup:
     !Equals [ !Ref LoadBalancerSecurityGroupId, '' ]
   CreateFrontendSecurityGroup:
-    !Equals [ !Ref FrontendSecurityGroupIds, '' ]
+    !Equals [ !Ref FrontendSecurityGroupId, '' ]
 
 # Should be the latest Amazon Linux AMI from: https://aws.amazon.com/amazon-linux-ami/
 # NOTE: If you wish to replace this AMI with your own RHEL-ish variety, be prepared to
@@ -385,10 +388,6 @@ Resources:
         IpProtocol: tcp
         SourceSecurityGroupId: !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
         ToPort: '443'
-      - FromPort: '22'
-        IpProtocol: tcp
-        SourceSecurityGroupId: !Ref SSHSecurityGroup
-        ToPort: '22'
       - FromPort: '10000'
         IpProtocol: tcp
         SourceSecurityGroupId: !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
@@ -399,6 +398,7 @@ Resources:
       VpcId: !Ref VPC
 
   LoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
     Condition: CreateLoadBalancerSecurityGroup
     Properties:
       GroupDescription: Setup Ingress/Egress for Chef Frontend Load Balancer
@@ -424,7 +424,6 @@ Resources:
       - Key: Name
         Value: !Sub ${AWS::StackName}-ELB-SG
       VpcId: !Ref VPC
-    Type: AWS::EC2::SecurityGroup
 
   # A special ELB just for Push Jobs traffic (TCP ports 10000-10003)
   # Note: Push Jobs server isn't truly HA. Although job state is stored in the database,
@@ -558,9 +557,8 @@ Resources:
       InstanceType: !Ref InstanceType
       KeyName: !Ref KeyName
       SecurityGroups:
-      - !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
-      - !Ref SSHSecurityGroup
-      - !If [CreateFrontendSecurityGroup, !Ref FrontendSecurityGroup, !Ref FrontendSecurityGroupIds]
+      - !If [CreateFrontendSecurityGroup, !Ref FrontendSecurityGroup, !Ref FrontendSecurityGroupId]
+      - !Ref InboundAdminSecurityGroup
       UserData:
         "Fn::Base64": !Sub |
           #!/bin/bash -x
@@ -719,7 +717,7 @@ Resources:
         - IpProtocol: tcp
           FromPort: 5432
           ToPort: 5432
-          SourceSecurityGroupId: !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
+          SourceSecurityGroupId: !If [CreateFrontendSecurityGroup, !Ref FrontendSecurityGroup, !Ref FrontendSecurityGroupId]
 
   DBSubnetGroup:
     Type: AWS::RDS::DBSubnetGroup

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -106,6 +106,10 @@ Parameters:
     AllowedValues:
     - 'internet-facing'
     - 'internal'
+  LoadBalancerSecurityGroupId:
+    Description: Supply a security group for your load balancer (leave blank to have it created for you). Using the default security group is recommended.
+    Type: String
+    Default: ''
   ChefServerAssociatePublicIpAddress:
     Description: Assign public IP addresses to the Chef Servers or not
     Type: String
@@ -195,6 +199,8 @@ Conditions:
     !Equals [ !Ref ChefServerIamRole, '' ]
   CreateChefSecretsBucket:
     !Equals [ !Ref ChefSecretsBucket, '' ]
+  CreateLoadBalancerSecurityGroup:
+    !Equals [ !Ref LoadBalancerSecurityGroupId, '' ]
 
 # Should be the latest Amazon Linux AMI from: https://aws.amazon.com/amazon-linux-ami/
 # NOTE: If you wish to replace this AMI with your own RHEL-ish variety, be prepared to
@@ -367,11 +373,11 @@ Resources:
       SecurityGroupIngress:
       - FromPort: '80'
         IpProtocol: tcp
-        SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
+        SourceSecurityGroupId: !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
         ToPort: '80'
       - FromPort: '443'
         IpProtocol: tcp
-        SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
+        SourceSecurityGroupId: !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
         ToPort: '443'
       - FromPort: '22'
         IpProtocol: tcp
@@ -379,7 +385,7 @@ Resources:
         ToPort: '22'
       - FromPort: '10000'
         IpProtocol: tcp
-        SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
+        SourceSecurityGroupId: !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
         ToPort: '10003'
       Tags:
       - Key: Name
@@ -387,6 +393,7 @@ Resources:
       VpcId: !Ref VPC
 
   LoadBalancerSecurityGroup:
+    Condition: CreateLoadBalancerSecurityGroup
     Properties:
       GroupDescription: Setup Ingress/Egress for Chef Frontend Load Balancer
       SecurityGroupEgress:
@@ -422,7 +429,7 @@ Resources:
     Type: "AWS::ElasticLoadBalancing::LoadBalancer"
     Properties:
       SecurityGroups:
-        - !Ref LoadBalancerSecurityGroup
+        - !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
       Subnets: !Ref ChefServerSubnets
       Scheme: !Ref LoadBalancerScheme
       Listeners:
@@ -448,7 +455,7 @@ Resources:
     Properties:
       Name: !Sub ${AWS::StackName}-lb
       SecurityGroups:
-        - !Ref LoadBalancerSecurityGroup
+        - !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
       Subnets: !Ref ChefServerSubnets
       # IpAddressType: dualstack
       Scheme: !Ref LoadBalancerScheme

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: AWS Native Chef Server v3.0.0
+Description: AWS Native Chef Server v3.1.0
 
 Parameters:
   # Required Parameters
@@ -32,9 +32,14 @@ Parameters:
   ###############################################################################
   # Performance Settings
   InstanceType:
-    ConstraintDescription: must be a valid EC2 instance type.
-    Default: c4.large
+    ConstraintDescription: EC2 Instance type for Chef Server Frontends (high-CPU recommended)
+    Default: c5.large
     Type: String
+    AllowedValues: [t2.small, t2.medium, t2.large, t2.xlarge, t2.2xlarge,
+      m4.large, m4.xlarge, m4.2xlarge, m4.4xlarge, m4.10xlarge, m4.16xlarge,
+      m5.large, m5.xlarge, m5.2xlarge, m5.4xlarge, m5.12xlarge, m5.24xlarge,
+      c4.large, c4.xlarge, c4.2xlarge, c4.4xlarge, c4.8xlarge,
+      c5.large, c5.xlarge, c5.2xlarge, c5.4xlarge, c5.9xlarge, c5.18xlarge]
   MaxFrontendInstances:
     Description: The maximum number of additional frontend instances to launch
     Type: Number
@@ -48,9 +53,12 @@ Parameters:
     Description: Enter how many licenses you have purchased
     Type: String
   DBInstanceClass:
-    Description: Storage size allocated for the database
+    Description: EC2 Instance type for RDS DBs (EBS Optimized instances recommended)
     Default: 'db.m4.large'
     Type: String
+    AllowedValues: [db.t2.medium, db.t2.large, db.t2.xlarge, db.t2.2xlarge,
+      db.m4.large, db.m4.xlarge, db.m4.2xlarge, db.m4.4xlarge, db.m4.10xlarge, db.m4.16xlarge,
+      db.r4.large, db.r4.xlarge, db.r4.2xlarge, db.r4.4xlarge, db.r4.8xlarge, db.r4.16xlarge]
   DBAllocatedStorage:
     Description: Storage size allocated for the database
     Default: '100'
@@ -59,6 +67,15 @@ Parameters:
     Description: IOPS allocated to the storage (storage size * 10)
     Default: '1000'
     Type: String
+  ElasticSearchInstanceType:
+    Description: The Instance type to use for ElasticSearch instances (Note, must have ephemeral storage, the instance type affects the total amount of elasticsearch storage. i3 strongly recommended)
+    Type: String
+    Default: 'i3.large.elasticsearch'
+    AllowedValues: [
+      'i3.large.elasticsearch', 'i3.xlarge.elasticsearch', 'i3.2xlarge.elasticsearch', 'i3.4xlarge.elasticsearch', 'i3.8xlarge.elasticsearch', 'i3.16xlarge.elasticsearch',
+      'i2.xlarge.elasticsearch', 'i2.2xlarge.elasticsearch',
+      'm3.medium.elasticsearch', 'm3.large.elasticsearch', 'm3.xlarge.elasticsearch', 'm3.medium.elasticsearch',
+      'r3.large.elasticsearch', 'r3.xlarge.elasticsearch', 'r3.2xlarge.elasticsearch', 'r3.4xlarge.elasticsearch', 'r3.8xlarge.elasticsearch' ]
   ElasticSearchVersion:
     Description: Version of ElasticSearch to use. Chef 12.16 supports v2.3 or 5.3. (5.3 recommended for new installs)
     Type: String
@@ -80,7 +97,7 @@ Parameters:
   ChefServerPackage:
     Description: The URL to the chef server EL7 (chef-server-core) package which will be downloaded
     Type: String
-    Default: 'https://packages.chef.io/files/stable/chef-server/12.16.14/el/7/chef-server-core-12.16.14-1.el7.x86_64.rpm'
+    Default: 'https://packages.chef.io/files/stable/chef-server/12.17.15/el/7/chef-server-core-12.17.15-1.el7.x86_64.rpm'
   ChefManagePackage:
     Description: The URL to the chef-manage EL7 package which will be downloaded
     Type: String
@@ -187,6 +204,7 @@ Metadata:
           - DBInstanceClass
           - DBAllocatedStorage
           - DBIops
+          - ElasticSearchInstanceType
           - ElasticSearchVersion
           - ElasticSearchShardCount
           - ElasticSearchReplicaCount
@@ -228,13 +246,13 @@ Conditions:
 Mappings:
   AWSRegion2AMI:
     us-east-1:
-      AMI: ami-8c1be5f6
+      AMI: ami-55ef662f
     us-east-2:
-      AMI: ami-c5062ba0
+      AMI: ami-15e9c770
     us-west-1:
-      AMI: ami-02eada62
+      AMI: ami-a51f27c5
     us-west-2:
-      AMI: ami-e689729e
+      AMI: ami-bf4193c7
 
 Resources:
 # Frontend Autoscale Groups
@@ -719,7 +737,7 @@ Resources:
   DBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: "Frontend Access"
+      GroupDescription: "RDS Frontend Access"
       VpcId: !Ref VPC
       SecurityGroupIngress:
         - IpProtocol: tcp
@@ -746,7 +764,7 @@ Resources:
       StorageType: io1
       MultiAZ: true
       Engine: postgres
-      EngineVersion: 9.6.3
+      EngineVersion: 9.6.5
       AllowMajorVersionUpgrade: true
       AutoMinorVersionUpgrade: true
       BackupRetentionPeriod: 35
@@ -764,6 +782,17 @@ Resources:
 
 # ElasticSearch
 #########################################################################################
+  ESSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "Elasticsearch Frontend Access"
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          SourceSecurityGroupId: !If [CreateFrontendSecurityGroup, !Ref FrontendSecurityGroup, !Ref FrontendSecurityGroupId]
+
   ElasticsearchDomain:
     Type: AWS::Elasticsearch::Domain
     Properties:
@@ -771,7 +800,7 @@ Resources:
       ElasticsearchClusterConfig:
         InstanceCount: !Sub ${ElasticSearchShardCount}
         ZoneAwarenessEnabled: false
-        InstanceType: m3.large.elasticsearch
+        InstanceType: !Ref ElasticSearchInstanceType
         DedicatedMasterEnabled: false
       SnapshotOptions:
         AutomatedSnapshotStartHour: "0"
@@ -782,6 +811,11 @@ Resources:
             Principal:
               AWS: !If [CreateChefServerIamRole, !GetAtt ChefRole.Arn, !Sub "arn:aws:iam::${AWS::AccountId}:role/${ChefServerIamRole}"]
             Action: "es:*"
+      VPCOptions:
+        SubnetIds:
+          - !Select [ 0, !Ref ChefServerSubnets ]
+        SecurityGroupIds:
+          - !Ref ESSecurityGroup
       AdvancedOptions:
         rest.action.multi.allow_explicit_index: "true"
       Tags:

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -92,11 +92,11 @@ Parameters:
   BeforeScriptLocation:
     Description: The S3 bucket location of the script which runs before the Main script
     Type: String
-    Default: s3://aws-native-chef-server/files/before.sh
+    Default: '' 
   AfterScriptLocation:
     Description: The S3 bucket location of the script which runs after the Main script
     Type: String
-    Default: s3://aws-native-chef-server/files/after.sh
+    Default: ''
   ###############################################################################
   # Security Settings
   LoadBalancerScheme:
@@ -655,11 +655,11 @@ Resources:
               command: initctl start aws-signing-proxy
             02_before_script:
               command: !Sub |
-                if [ -n ${BeforeScriptLocation} ]; then
+                if [ -n '${BeforeScriptLocation}' ]; then
                     aws s3 cp ${BeforeScriptLocation} /tmp/before.sh
                     bash -x /tmp/before.sh
                 fi
-                if [ -n ${ChefServerCustomConfig} ]; then
+                if [ -n '${ChefServerCustomConfig}' ]; then
                     aws s3 cp ${ChefServerCustomConfig} /etc/opscode/chef-server-custom.rb
                     echo "# Appended from chef-server-custom.rb" >> /etc/opscode/chef-server.rb
                     cat /etc/opscode/chef-server-custom.rb >> /etc/opscode/chef-server.rb
@@ -676,10 +676,10 @@ Resources:
               - { S3BUCKET: !If [CreateChefSecretsBucket, !Ref ChefBucket, !Ref ChefSecretsBucket] }
             04_after_script:
               command: !Sub |
-                if [ -n ${AfterScriptLocation} ]; then
+                if [ -n '${AfterScriptLocation}' ]; then
                   aws s3 cp ${AfterScriptLocation} /tmp/after.sh
                   bash -x /tmp/after.sh
-                end
+                fi
             05_configure_cloudwatch_monitoring:
               command: !Sub |
                 mkdir /opt/cloudwatch_monitoring

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -13,7 +13,7 @@ Parameters:
     Default: 'arn:aws:iam::'
     Description: SSL Certficate ARN for SSL Certficate
     Type: String
-  InboundAdminSecurityGroup:
+  InboundAdminSecurityGroupId:
     Description: Select an existing Security Group in your VPC to define administrative ACLs (SSH, monitoring tools, etc) to the Chef servers
     Type: AWS::EC2::SecurityGroup::Id
   KeyName:
@@ -172,7 +172,7 @@ Metadata:
           - VPC
           - ChefServerSubnets
           - SSLCertificateARN
-          - InboundAdminSecurityGroup
+          - InboundAdminSecurityGroupId
           - KeyName
           - DBPassword
           - ContactEmail
@@ -567,7 +567,7 @@ Resources:
       KeyName: !Ref KeyName
       SecurityGroups:
       - !If [CreateFrontendSecurityGroup, !Ref FrontendSecurityGroup, !Ref FrontendSecurityGroupId]
-      - !Ref InboundAdminSecurityGroup
+      - !Ref InboundAdminSecurityGroupId
       UserData:
         "Fn::Base64": !Sub |
           #!/bin/bash -x

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: AWS Native Chef Server v2.5.0
+Description: AWS Native Chef Server v3.0.0
 
 Parameters:
   ChefServerPackage:
@@ -22,9 +22,6 @@ Parameters:
     Description: The maximum number of additional frontend instances to launch
     Type: Number
     Default: 3
-  LoadBalancerSubnets:
-    Description: Provide a list of Subnet IDs for the ELB
-    Type: List<AWS::EC2::Subnet::Id>
   LoadBalancerScheme:
     Description: Network Scheme for the ELB
     Type: String
@@ -69,10 +66,6 @@ Parameters:
   DBInstanceClass:
     Description: Storage size allocated for the database
     Default: 'db.m4.large'
-    Type: String
-  DBSubnetGroupArn:
-    Description: Provide a DB Subnet Group ARN (or leave blank to have one created for you)
-    Default: ''
     Type: String
   ElasticSearchVersion:
     Description: Version of ElasticSearch to use. Chef 12.16 supports v2.3 or 5.3. (5.3 recommended for new installs)
@@ -142,8 +135,6 @@ Conditions:
     !Equals [ !Ref ChefServerIamRole, '' ]
   CreateChefSecretsBucket:
     !Equals [ !Ref ChefSecretsBucket, '' ]
-  CreateDBSubnetGroup:
-    !Equals [ !Ref DBSubnetGroupArn, '' ]
 
 # Should be the latest Amazon Linux AMI from: https://aws.amazon.com/amazon-linux-ami/
 Mappings:
@@ -368,7 +359,7 @@ Resources:
     Properties:
       SecurityGroups:
         - !Ref LoadBalancerSecurityGroup
-      Subnets: !Ref LoadBalancerSubnets
+      Subnets: !Ref ChefServerSubnets
       Scheme: !Ref LoadBalancerScheme
       Listeners:
         - LoadBalancerPort: '10000'
@@ -394,7 +385,7 @@ Resources:
       Name: !Sub ${AWS::StackName}-lb
       SecurityGroups:
         - !Ref LoadBalancerSecurityGroup
-      Subnets: !Ref LoadBalancerSubnets
+      Subnets: !Ref ChefServerSubnets
       # IpAddressType: dualstack
       Scheme: !Ref LoadBalancerScheme
       Tags:
@@ -630,7 +621,6 @@ Resources:
           SourceSecurityGroupId: !Ref FrontendSecurityGroup
 
   DBSubnetGroup:
-    Condition: CreateDBSubnetGroup
     Type: AWS::RDS::DBSubnetGroup
     Properties:
       DBSubnetGroupDescription: RDS DB subnet group
@@ -653,7 +643,7 @@ Resources:
       AllowMajorVersionUpgrade: true
       AutoMinorVersionUpgrade: true
       BackupRetentionPeriod: 35
-      DBSubnetGroupName: !If [CreateDBSubnetGroup, !Ref DBSubnetGroup, !Ref DBSubnetGroupArn]
+      DBSubnetGroupName: !Ref DBSubnetGroup
       VPCSecurityGroups:
         - !Ref DBSecurityGroup
       PubliclyAccessible: false

--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -142,6 +142,9 @@ Parameters:
     Default: ''
     Description: Default Chef organization name (typically only used when migrating from Chef Server 11, otherwise leave blank)
     Type: String
+  ChefServerCustomConfig:
+    Default: ''
+    Type: String
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -645,8 +648,15 @@ Resources:
               command: initctl start aws-signing-proxy
             02_before_script:
               command: !Sub |
-                aws s3 cp ${BeforeScriptLocation} /tmp/before.sh
-                bash -x /tmp/before.sh
+                if [ -n ${BeforeScriptLocation} ]; then
+                    aws s3 cp ${BeforeScriptLocation} /tmp/before.sh
+                    bash -x /tmp/before.sh
+                fi
+                if [ -n ${ChefServerCustomConfig} ]; then
+                    aws s3 cp ${ChefServerCustomConfig} /etc/opscode/chef-server-custom.rb
+                    echo "# Appended from chef-server-custom.rb" >> /etc/opscode/chef-server.rb
+                    cat /etc/opscode/chef-server-custom.rb >> /etc/opscode/chef-server.rb
+                fi
             03_configure_chef_server:
               command: !Sub
               - |
@@ -659,8 +669,10 @@ Resources:
               - { S3BUCKET: !If [CreateChefSecretsBucket, !Ref ChefBucket, !Ref ChefSecretsBucket] }
             04_after_script:
               command: !Sub |
-                aws s3 cp ${AfterScriptLocation} /tmp/after.sh
-                bash -x /tmp/after.sh
+                if [ -n ${AfterScriptLocation} ]; then
+                  aws s3 cp ${AfterScriptLocation} /tmp/after.sh
+                  bash -x /tmp/after.sh
+                end
             05_configure_cloudwatch_monitoring:
               command: !Sub |
                 mkdir /opt/cloudwatch_monitoring

--- a/files/after.sh
+++ b/files/after.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# place your customizations here, for things that run after main.sh
+
+exit 0

--- a/files/before.sh
+++ b/files/before.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# place your customizations here, for things that run before main.sh
+
+exit 0

--- a/stack_parameters.json.example
+++ b/stack_parameters.json.example
@@ -24,7 +24,7 @@
     "ParameterValue": "vpc-fa58989d"
   },
   {
-    "ParameterKey":   "InboundAdminSecurityGroup",
+    "ParameterKey":   "InboundAdminSecurityGroupId",
     "ParameterValue": "sg-bddcfbc4"
   },
   {

--- a/stack_parameters.json.example
+++ b/stack_parameters.json.example
@@ -1,7 +1,7 @@
 [
   {
     "ParameterKey":   "ElasticSearchVersion",
-    "ParameterValue": "5.3"
+    "ParameterValue": "5.5"
   },
   {
     "ParameterKey":   "SSLCertificateARN",
@@ -10,10 +10,6 @@
   {
     "ParameterKey":   "LicenseCount",
     "ParameterValue": "999999"
-  },
-  {
-    "ParameterKey":   "DBUser",
-    "ParameterValue": "chefadmin"
   },
   {
     "ParameterKey":   "DBPassword",
@@ -28,12 +24,8 @@
     "ParameterValue": "vpc-fa58989d"
   },
   {
-    "ParameterKey":   "SSHSecurityGroup",
+    "ParameterKey":   "InboundAdminSecurityGroup",
     "ParameterValue": "sg-bddcfbc4"
-  },
-  {
-    "ParameterKey":   "LoadBalancerSubnets",
-    "ParameterValue": "subnet-63c62b04,subnet-dc1611aa,subnet-0247365a"
   },
   {
     "ParameterKey":   "LoadBalancerScheme",
@@ -62,9 +54,5 @@
   {
     "ParameterKey":   "ContactDept",
     "ParameterValue": "success"
-  },
-  {
-    "ParameterKey":   "ChefDefaultOrgName",
-    "ParameterValue": ""
   }
 ]

--- a/stack_parameters.json.example
+++ b/stack_parameters.json.example
@@ -41,11 +41,11 @@
   },
   {
     "ParameterKey":   "InstanceType",
-    "ParameterValue": "c4.large"
+    "ParameterValue": "c5.xlarge"
   },
   {
     "ParameterKey":   "DBInstanceClass",
-    "ParameterValue": "db.m4.large"
+    "ParameterValue": "db.m4.xlarge"
   },
   {
     "ParameterKey":   "ContactEmail",


### PR DESCRIPTION
# What's changed
1. Remove never-used parameters `DBSubnetGroupArn` and `LoadBalancerSubnets`
2. Reorganize parameters for easier consumption
3. Enable users to provide custom before and after scripts. Also switch to explicit S3 files locations for those scripts.
4. Add configurables for a Chef Automate data collector
5. Enable users to provide their own security group IDs for the frontends and load balancers
6. Route53 integration
7. Enable and recommend newer instance types like C5, M5 and I3 where available
8. Move Elasticsearch into the VPC! woohoo!
9. Make Elasticsearch instance type configurable, and default to i3.large which is a way better bang-for-buck than the old m3 options.
10. the template is now officially too big to be run from disk (via `template-body`), so now it must be run from S3 (via `template-url`) so updating the workflow to match that.

Because these changes break backwards compatibility, I'm bumping the major release version and including a fun image to make it easier:
![the fear of increasing the major version number](https://pbs.twimg.com/media/DLY5l8VVwAIUWCd.jpg)

