### PR TITLE
add MinFrontendInstances parameter

### DIFF
--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -22,6 +22,10 @@ Parameters:
     Description: The maximum number of additional frontend instances to launch
     Type: Number
     Default: 3
+  MinFrontendInstances:
+    Description: The minimum number of frontend instances to launch
+    Type: Number
+    Default: 1
   LoadBalancerSubnets:
     Description: Provide a list of Subnet IDs for the ELB
     Type: List<AWS::EC2::Subnet::Id>
@@ -199,7 +203,7 @@ Resources:
       TargetGroupARNs:
       - !Ref ChefTargetGroup
       MaxSize: !Sub '${MaxFrontendInstances}'
-      MinSize: '1'
+      MinSize: !Sub '${MinFrontendInstances}'
       Tags:
       - Key: Name
         Value: !Sub ${AWS::StackName}-frontend


### PR DESCRIPTION
This adds the ability to pass in `MinFrontendInstances` via `stack_parameters.json`

Signed-off-by: Jeremy J. Miller <jm@chef.io>