### PR TITLE
Adding SNS notifications for RDS and AutoScalingGroup

### DIFF
--- a/backendless_chef.yaml
+++ b/backendless_chef.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: AWS Native Chef Server v3.2.0
+Description: AWS Native Chef Server v3.3.0
 
 Parameters:
   # Required Parameters
@@ -299,6 +299,13 @@ Resources:
       - !Ref ChefPJELB
       MaxSize: '1'
       MinSize: '1'
+      NotificationConfigurations:
+      - TopicARN: !Ref AlertNotificationTopic
+        NotificationTypes:
+        - autoscaling:EC2_INSTANCE_LAUNCH
+        - autoscaling:EC2_INSTANCE_LAUNCH_ERROR
+        - autoscaling:EC2_INSTANCE_TERMINATE
+        - autoscaling:EC2_INSTANCE_TERMINATE_ERROR
       Tags:
       - Key: Name
         Value: !Sub ${AWS::StackName}-bootstrap-frontend
@@ -323,6 +330,13 @@ Resources:
       - !Ref ChefTargetGroup
       MaxSize: !Sub '${MaxFrontendInstances}'
       MinSize: !Sub '${MinFrontendInstances}'
+      NotificationConfigurations:
+      - TopicARN: !Ref AlertNotificationTopic
+        NotificationTypes:
+        - autoscaling:EC2_INSTANCE_LAUNCH
+        - autoscaling:EC2_INSTANCE_LAUNCH_ERROR
+        - autoscaling:EC2_INSTANCE_TERMINATE
+        - autoscaling:EC2_INSTANCE_TERMINATE_ERROR
       Tags:
       - Key: Name
         Value: !Sub ${AWS::StackName}-frontend
@@ -964,6 +978,14 @@ Resources:
           Value: !Ref ContactDept
         - Key: X-Contact
           Value: !Ref ContactEmail
+
+  RdsEventSubscription:
+    Type: AWS::RDS::EventSubscription
+    Properties:
+      SnsTopicArn: !Ref AlertNotificationTopic
+      SourceIds:
+        - !Ref DBPostgres
+      SourceType: db-instance
 
 # ElasticSearch
 #########################################################################################


### PR DESCRIPTION
Our operators should know when actions are being taken, especially when they're being taken without their knowledge or intervention.   This PR adds notifications for RDS and AutoScaling group actions, which go to the Alert notification topic (for consumption by email and/or alerting systems)

Fixes: #30 
