### PR TITLE
Add ability to enter subnets for ELBs and RDS DB

### DIFF
--- a/automate.yaml
+++ b/automate.yaml
@@ -7,8 +7,8 @@ Parameters:
     Description: Choose VPC to use
     Type: AWS::EC2::VPC::Id
   LoadBalancerSubnets:
-    Description: Provide a list of Subnet IDs for the Load Balancers (must be at least 2 within the specified VPC)
-    Type: List<AWS::EC2::Subnet::Id>
+    Description: Provide a comma separated list of Subnet IDs for the Load Balancers (must be at least 2 within the specified VPC)
+    Type: CommaDelimitedList
   AutomateSubnet:
     Description: Provide a single Subnet ID for the Automate Server (must be within the specified VPC)
     Type: AWS::EC2::Subnet::Id
@@ -96,8 +96,6 @@ Metadata:
 Conditions:
   CreateRoute53Record:
     !Not [!Equals [ !Ref Route53HostedZone, '' ] ]
-  UsePublicIp:
-    !Equals [ !Ref LoadBalancerScheme, 'internet-facing']
 
 Resources:
   AutomateInstanceProfile:
@@ -573,4 +571,4 @@ Outputs:
       Name: !Sub "${AWS::StackName}-DNSName"
   ServerIP:
     Description: The IP Address of the Automate Server
-    Value: !If [UsePublicIp, !GetAtt AutomateServer.PublicIp, !GetAtt AutomateServer.PrivateIp]
+    Value: !GetAtt AutomateServer.PrivateIp

--- a/automate.yaml
+++ b/automate.yaml
@@ -7,8 +7,8 @@ Parameters:
     Description: Choose VPC to use
     Type: AWS::EC2::VPC::Id
   LoadBalancerSubnets:
-    Description: Provide a comma separated list of Subnet IDs for the Load Balancers (must be at least 2 within the specified VPC)
-    Type: CommaDelimitedList
+    Description: Provide a list of Subnet IDs for the Load Balancers (must be at least 2 within the specified VPC)
+    Type: List<AWS::EC2::Subnet::Id>
   AutomateSubnet:
     Description: Provide a single Subnet ID for the Automate Server (must be within the specified VPC)
     Type: AWS::EC2::Subnet::Id

--- a/chef_server_ha.yaml
+++ b/chef_server_ha.yaml
@@ -14,11 +14,11 @@ Parameters:
     Description: Provide a list of Subnet IDs for the Chef Servers (must be within the specified VPC)
     Type: List<AWS::EC2::Subnet::Id>
   LoadBalancerSubnets:
-    Description: Provide a list of Subnet IDs for the load balancers (Leave blank to use the ServerSubnets specified above)
-    Type: List<AWS::EC2::Subnet::Id>
+    Description: Provide a comma separated list of Subnet IDs for the load balancers (Leave blank to use the ChefServerSubnets specified above)
+    Type: CommaDelimitedList
   DatabaseSubnets:
-    Description: Provide a list of Subnet IDs for the Postgres database (Leave blank to use the ServerSubnets specified above)
-    Type: List<AWS::EC2::Subnet::Id>
+    Description: Provide a comma separated list of Subnet IDs for the Postgres database (Leave blank to use the ChefServerSubnets specified above)
+    Type: CommaDelimitedList
   SSLCertificateARN:
     Description: SSL Certficate ARN for SSL Certficate
     Type: String
@@ -310,7 +310,7 @@ Resources:
     Properties:
       SecurityGroups:
         - !Ref LoadBalancerSecurityGroupId
-      Subnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets]]
+      Subnets: !If [UseServerSubnetsForLoadBalancers, !Ref ChefServerSubnets, !Ref LoadBalancerSubnets ]
       Scheme: !Ref LoadBalancerScheme
       Listeners:
         - LoadBalancerPort: '10000'
@@ -335,7 +335,7 @@ Resources:
     Properties:
       SecurityGroups:
         - !Ref LoadBalancerSecurityGroupId
-      Subnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets]]
+      Subnets: !If [UseServerSubnetsForLoadBalancers, !Ref ChefServerSubnets, !Ref LoadBalancerSubnets ]
       # IpAddressType: dualstack
       Scheme: !Ref LoadBalancerScheme
       Tags:
@@ -722,7 +722,7 @@ Resources:
       TemplateURL: !Sub https://${AutomationBucket}.s3.amazonaws.com/${TemplateVersion}/chef_rds.yaml
       Parameters:
         VPC: !Sub ${VPC}
-        ChefServerSubnets: !If [UseServerSubnetsForDatabase, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref DatabaseSubnets]]
+        ChefServerSubnets: !If [UseServerSubnetsForDatabase, !Join [ ",", !Ref ChefServerSubnets ], !Join [ ",", !Ref DatabaseSubnets ] ]
         DBPassword: !Ref DBPassword
         ContactEmail: !Ref ContactEmail
         ContactDept: !Ref ContactDept

--- a/chef_server_ha.yaml
+++ b/chef_server_ha.yaml
@@ -13,6 +13,12 @@ Parameters:
   ChefServerSubnets:
     Description: Provide a list of Subnet IDs for the Chef Servers (must be within the specified VPC)
     Type: List<AWS::EC2::Subnet::Id>
+  LoadBalancerSubnets:
+    Description: Provide a list of Subnet IDs for the load balancers (Leave blank to use the ServerSubnets specified above)
+    Type: List<AWS::EC2::Subnet::Id>
+  DatabaseSubnets:
+    Description: Provide a list of Subnet IDs for the Postgres database (Leave blank to use the ServerSubnets specified above)
+    Type: List<AWS::EC2::Subnet::Id>
   SSLCertificateARN:
     Description: SSL Certficate ARN for SSL Certficate
     Type: String
@@ -196,6 +202,10 @@ Metadata:
 Conditions:
   CreateRoute53Record:
     !Not [!Equals [ !Ref Route53HostedZone, '' ] ]
+  UseServerSubnetsForLoadBalancers:
+    !Equals [ !Select [ 0, !Ref LoadBalancerSubnets], '' ]
+  UseServerSubnetsForDatabase:
+    !Equals [ !Select [ 0, !Ref DatabaseSubnets], '' ]
 
 Resources:
 # Frontend Autoscale Groups
@@ -300,7 +310,7 @@ Resources:
     Properties:
       SecurityGroups:
         - !Ref LoadBalancerSecurityGroupId
-      Subnets: !Ref ChefServerSubnets
+      Subnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets]]
       Scheme: !Ref LoadBalancerScheme
       Listeners:
         - LoadBalancerPort: '10000'
@@ -325,7 +335,7 @@ Resources:
     Properties:
       SecurityGroups:
         - !Ref LoadBalancerSecurityGroupId
-      Subnets: !Ref ChefServerSubnets
+      Subnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets]]
       # IpAddressType: dualstack
       Scheme: !Ref LoadBalancerScheme
       Tags:
@@ -712,7 +722,7 @@ Resources:
       TemplateURL: !Sub https://${AutomationBucket}.s3.amazonaws.com/${TemplateVersion}/chef_rds.yaml
       Parameters:
         VPC: !Sub ${VPC}
-        ChefServerSubnets: !Join [ ",", !Ref ChefServerSubnets ]
+        ChefServerSubnets: !If [UseServerSubnetsForDatabase, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref DatabaseSubnets]]
         DBPassword: !Ref DBPassword
         ContactEmail: !Ref ContactEmail
         ContactDept: !Ref ContactDept

--- a/chef_server_ha.yaml
+++ b/chef_server_ha.yaml
@@ -19,6 +19,9 @@ Parameters:
   DatabaseSubnets:
     Description: Provide a comma separated list of Subnet IDs for the Postgres database (Leave blank to use the ChefServerSubnets specified above)
     Type: CommaDelimitedList
+  ElasticSearchSubnets:
+    Description: Provide a comma separated list of Subnet IDs for the ElasticSearch cluster (Leave blank to use the ChefServerSubnets specified above)
+    Type: CommaDelimitedList
   SSLCertificateARN:
     Description: SSL Certficate ARN for SSL Certficate
     Type: String
@@ -206,6 +209,8 @@ Conditions:
     !Equals [ !Select [ 0, !Ref LoadBalancerSubnets], '' ]
   UseServerSubnetsForDatabase:
     !Equals [ !Select [ 0, !Ref DatabaseSubnets], '' ]
+  UseServerSubnetsForElasticSearch:
+    !Equals [ !Select [ 0, !Ref ElasticSearchSubnets], '' ]
 
 Resources:
 # Frontend Autoscale Groups
@@ -742,7 +747,7 @@ Resources:
       TemplateURL: !Sub https://${AutomationBucket}.s3.amazonaws.com/${TemplateVersion}/chef_elasticsearch.yaml
       Parameters:
         VPC: !Sub ${VPC}
-        ChefServerSubnets: !Join [ ",", !Ref ChefServerSubnets ]
+        ChefServerSubnets: !If [UseServerSubnetsForElasticSearch, !Join [ ",", !Ref ChefServerSubnets ], !Join [ ",", !Ref ElasticSearchSubnets ] ]
         ContactEmail: !Ref ContactEmail
         ContactDept: !Ref ContactDept
         ElasticSearchInstanceType: !Ref ElasticSearchInstanceType

--- a/main.yaml
+++ b/main.yaml
@@ -14,11 +14,11 @@ Parameters:
     Description: Provide a list of Subnet IDs for the Chef Servers (must be within the specified VPC)
     Type: List<AWS::EC2::Subnet::Id>
   LoadBalancerSubnets:
-    Description: Provide a list of Subnet IDs for the load balancers (Leave blank to use the ServerSubnets specified above)
-    Type: List<AWS::EC2::Subnet::Id>
+    Description: Provide a comma separated list of Subnet IDs for the load balancers (Leave blank to use the ServerSubnets specified above)
+    Type: CommaDelimitedList
   DatabaseSubnets:
-    Description: Provide a list of Subnet IDs for the Postgres database (Leave blank to use the ServerSubnets specified above)
-    Type: List<AWS::EC2::Subnet::Id>
+    Description: Provide a comma separated list of Subnet IDs for the Postgres database (Leave blank to use the ServerSubnets specified above)
+    Type: CommaDelimitedList
   InboundAdminSecurityGroupId:
     Description: Select an existing Security Group in your VPC to define administrative ACLs (SSH, monitoring tools, etc) to the Chef servers
     Type: AWS::EC2::SecurityGroup::Id
@@ -476,7 +476,6 @@ Resources:
       TemplateURL: !Sub https://${AutomationBucket}.s3.amazonaws.com/${TemplateVersion}/automate.yaml
       Parameters:
         VPC: !Ref VPC
-        LoadBalancerSubnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets]]
         AutomateSubnet: !Select [ "0", !Ref ServerSubnets ]
         SSLCertificateARN: !Ref AutomateSSLCertificateARN
         AutomateAdminPassword: !Ref ChefAutomateAdminPassword
@@ -491,6 +490,7 @@ Resources:
         AutomateDataCollectorToken: !Ref ChefAutomateToken
         LoadBalancerScheme: !Ref LoadBalancerScheme
         LoadBalancerSecurityGroupId: !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
+        LoadBalancerSubnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets ] ]
         FrontendSecurityGroupId: !If [CreateFrontendSecurityGroup, !Ref FrontendSecurityGroup, !Ref FrontendSecurityGroupId]
         AutomateIamRole: !If [CreateChefIamRole, !Ref ChefRole, !Ref ExistingIamRole]
         Route53HostedZone: !Ref Route53HostedZone
@@ -522,11 +522,13 @@ Resources:
         DBAllocatedStorage: !Ref ChefDBAllocatedStorage
         DBIops: !Ref ChefDBIops
         DBBackupDaystoKeep: !Ref ChefDBBackupDaystoKeep
+        DatabaseSubnets: !If [UseServerSubnetsForDatabase, !Join [",", !Ref ServerSubnets], !Join [",", !Ref DatabaseSubnets]]
         ElasticSearchInstanceType: !Ref ChefElasticSearchInstanceType
         ElasticSearchVersion: !Ref ChefElasticSearchVersion
         ElasticSearchShardCount: !Ref ChefElasticSearchShardCount
         LoadBalancerScheme: !Ref LoadBalancerScheme
         LoadBalancerSecurityGroupId: !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
+        LoadBalancerSubnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets ] ]
         FrontendSecurityGroupId: !If [CreateFrontendSecurityGroup, !Ref FrontendSecurityGroup, !Ref FrontendSecurityGroupId]
         ChefServerAssociatePublicIpAddress: !Ref AssociatePublicIpAddress
         ChefServerIamRole: !If [CreateChefIamRole, !Ref ChefRole, !Ref ExistingIamRole]
@@ -548,7 +550,6 @@ Resources:
       TemplateURL: !Sub https://${AutomationBucket}.s3.amazonaws.com/${TemplateVersion}/supermarket.yaml
       Parameters:
         VPC: !Ref VPC
-        LoadBalancerSubnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets]]
         SupermarketSubnet: !Select [ "0", !Ref ServerSubnets ]
         SSLCertificateARN: !Ref SupermarketSSLCertificateARN
         InboundAdminSecurityGroupId: !Ref InboundAdminSecurityGroupId
@@ -562,6 +563,7 @@ Resources:
         DataVolumeSize: !Ref SupermarketDataVolumeSize
         LoadBalancerScheme: !Ref LoadBalancerScheme
         LoadBalancerSecurityGroupId: !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
+        LoadBalancerSubnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets ] ]
         FrontendSecurityGroupId: !If [CreateFrontendSecurityGroup, !Ref FrontendSecurityGroup, !Ref FrontendSecurityGroupId]
         SupermarketIamRole: !If [CreateChefIamRole, !Ref ChefRole, !Ref ExistingIamRole]
         ChefSecretsBucket: !If [CreateChefSecretsBucket, !Ref ChefBucket, !Ref ExistingSecretsBucket]

--- a/main.yaml
+++ b/main.yaml
@@ -19,6 +19,9 @@ Parameters:
   DatabaseSubnets:
     Description: Provide a comma separated list of Subnet IDs for the Postgres database (Leave blank to use the ServerSubnets specified above)
     Type: CommaDelimitedList
+  ElasticSearchSubnets:
+    Description: Provide a comma separated list of Subnet IDs for the ElasticSearch cluster (Leave blank to use the ServerSubnets specified above)
+    Type: CommaDelimitedList
   InboundAdminSecurityGroupId:
     Description: Select an existing Security Group in your VPC to define administrative ACLs (SSH, monitoring tools, etc) to the Chef servers
     Type: AWS::EC2::SecurityGroup::Id
@@ -280,6 +283,8 @@ Conditions:
     !Equals [ !Select [ 0, !Ref LoadBalancerSubnets], '' ]
   UseServerSubnetsForDatabase:
     !Equals [ !Select [ 0, !Ref DatabaseSubnets], '' ]
+  UseServerSubnetsForElasticSearch:
+    !Equals [ !Select [ 0, !Ref ElasticSearchSubnets], '' ]
 
 # STOP:  Do not replace the AMI list unless you 100% know what you're doing
 #        and are fully prepared to lose all support. This template now depends
@@ -526,6 +531,7 @@ Resources:
         ElasticSearchInstanceType: !Ref ChefElasticSearchInstanceType
         ElasticSearchVersion: !Ref ChefElasticSearchVersion
         ElasticSearchShardCount: !Ref ChefElasticSearchShardCount
+        ElasticSearchSubnets: !If [UseServerSubnetsForElasticSearch, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref ElasticSearchSubnets ] ]
         LoadBalancerScheme: !Ref LoadBalancerScheme
         LoadBalancerSecurityGroupId: !If [CreateLoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroup, !Ref LoadBalancerSecurityGroupId]
         LoadBalancerSubnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets ] ]

--- a/main.yaml
+++ b/main.yaml
@@ -228,6 +228,7 @@ Metadata:
           - ServerSubnets
           - LoadBalancerSubnets
           - DatabaseSubnets
+          - ElasticSearchSubnets
           - KeyName
           - InboundAdminSecurityGroupId
           - ContactEmail

--- a/main.yaml
+++ b/main.yaml
@@ -13,6 +13,12 @@ Parameters:
   ServerSubnets:
     Description: Provide a list of Subnet IDs for the Chef Servers (must be within the specified VPC)
     Type: List<AWS::EC2::Subnet::Id>
+  LoadBalancerSubnets:
+    Description: Provide a list of Subnet IDs for the load balancers (Leave blank to use the ServerSubnets specified above)
+    Type: List<AWS::EC2::Subnet::Id>
+  DatabaseSubnets:
+    Description: Provide a list of Subnet IDs for the Postgres database (Leave blank to use the ServerSubnets specified above)
+    Type: List<AWS::EC2::Subnet::Id>
   InboundAdminSecurityGroupId:
     Description: Select an existing Security Group in your VPC to define administrative ACLs (SSH, monitoring tools, etc) to the Chef servers
     Type: AWS::EC2::SecurityGroup::Id
@@ -217,6 +223,8 @@ Metadata:
         Parameters:
           - VPC
           - ServerSubnets
+          - LoadBalancerSubnets
+          - DatabaseSubnets
           - KeyName
           - InboundAdminSecurityGroupId
           - ContactEmail
@@ -268,6 +276,10 @@ Conditions:
     !Equals [ !Ref LoadBalancerSecurityGroupId, '' ]
   CreateFrontendSecurityGroup:
     !Equals [ !Ref FrontendSecurityGroupId, '' ]
+  UseServerSubnetsForLoadBalancers:
+    !Equals [ !Select [ 0, !Ref LoadBalancerSubnets], '' ]
+  UseServerSubnetsForDatabase:
+    !Equals [ !Select [ 0, !Ref DatabaseSubnets], '' ]
 
 # STOP:  Do not replace the AMI list unless you 100% know what you're doing
 #        and are fully prepared to lose all support. This template now depends
@@ -464,7 +476,7 @@ Resources:
       TemplateURL: !Sub https://${AutomationBucket}.s3.amazonaws.com/${TemplateVersion}/automate.yaml
       Parameters:
         VPC: !Ref VPC
-        LoadBalancerSubnets: !Join [ ",", !Ref ServerSubnets ]
+        LoadBalancerSubnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets]]
         AutomateSubnet: !Select [ "0", !Ref ServerSubnets ]
         SSLCertificateARN: !Ref AutomateSSLCertificateARN
         AutomateAdminPassword: !Ref ChefAutomateAdminPassword
@@ -536,7 +548,7 @@ Resources:
       TemplateURL: !Sub https://${AutomationBucket}.s3.amazonaws.com/${TemplateVersion}/supermarket.yaml
       Parameters:
         VPC: !Ref VPC
-        LoadBalancerSubnets: !Join [ ",", !Ref ServerSubnets ]
+        LoadBalancerSubnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets]]
         SupermarketSubnet: !Select [ "0", !Ref ServerSubnets ]
         SSLCertificateARN: !Ref SupermarketSSLCertificateARN
         InboundAdminSecurityGroupId: !Ref InboundAdminSecurityGroupId

--- a/marketplace.yaml
+++ b/marketplace.yaml
@@ -13,6 +13,12 @@ Parameters:
   ServerSubnets:
     Description: Provide a list of Subnet IDs for the Chef Servers (must be within the specified VPC)
     Type: List<AWS::EC2::Subnet::Id>
+  LoadBalancerSubnets:
+    Description: Provide a comma separated list of Subnet IDs for the load balancers (Leave blank to use the ServerSubnets specified above)
+    Type: CommaDelimitedList
+  DatabaseSubnets:
+    Description: Provide a comma separated list of Subnet IDs for the Postgres database (Leave blank to use the ServerSubnets specified above)
+    Type: CommaDelimitedList
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
     Type: AWS::EC2::KeyPair::KeyName
@@ -196,6 +202,10 @@ Parameters:
 Conditions:
   2ZoneES:
     !Equals [!Ref ChefElasticSearchShardCount, 2]
+  UseServerSubnetsForLoadBalancers:
+    !Equals [ !Select [ 0, !Ref LoadBalancerSubnets], '' ]
+  UseServerSubnetsForDatabase:
+    !Equals [ !Select [ 0, !Ref DatabaseSubnets], '' ]
 
 Metadata:
   cfn-lint:
@@ -472,6 +482,7 @@ Resources:
         AutomateDataCollectorToken: !Ref ChefAutomateToken
         LoadBalancerScheme: !Ref LoadBalancerScheme
         LoadBalancerSecurityGroupId: !Ref LoadBalancerSecurityGroup
+        LoadBalancerSubnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets ] ]
         FrontendSecurityGroupId: !Ref FrontendSecurityGroup
         AutomateIamRole: !Ref ChefRole
         Route53HostedZone: !Ref Route53HostedZone
@@ -503,12 +514,14 @@ Resources:
         DBAllocatedStorage: !Ref ChefDBAllocatedStorage
         DBIops: !Ref ChefDBIops
         DBBackupDaystoKeep: !Ref ChefDBBackupDaystoKeep
+        DatabaseSubnets: !If [UseServerSubnetsForDatabase, !Join [",", !Ref ServerSubnets], !Join [",", !Ref DatabaseSubnets]]
         ElasticSearchInstanceType: !Ref ChefElasticSearchInstanceType
         ElasticSearchVersion: !Ref ChefElasticSearchVersion
         ElasticSearchShardCount: !Ref ChefElasticSearchShardCount
         ElasticSearchReplicaCount: !If [2ZoneES, 1, 2]
         LoadBalancerScheme: !Ref LoadBalancerScheme
         LoadBalancerSecurityGroupId: !Ref LoadBalancerSecurityGroup
+        LoadBalancerSubnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets ] ]
         FrontendSecurityGroupId: !Ref FrontendSecurityGroup
         ChefServerAssociatePublicIpAddress: !Ref AssociatePublicIpAddress
         ChefServerIamRole: !Ref ChefRole
@@ -530,7 +543,7 @@ Resources:
       TemplateURL: !Sub https://${AutomationBucket}.s3.amazonaws.com/${TemplateVersion}/supermarket.yaml
       Parameters:
         VPC: !Ref VPC
-        LoadBalancerSubnets: !Join [ ",", !Ref ServerSubnets ]
+        LoadBalancerSubnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets ] ]
         SupermarketSubnet: !Select [ "0", !Ref ServerSubnets ]
         SSLCertificateARN: !Ref SupermarketSSLCertificateARN
         InboundAdminSecurityGroupId: !Ref InboundAdminSecurityGroupId

--- a/marketplace.yaml
+++ b/marketplace.yaml
@@ -224,6 +224,9 @@ Metadata:
         Parameters:
           - VPC
           - ServerSubnets
+          - LoadBalancerSubnets
+          - DatabaseSubnets
+          - ElasticSearchSubnets
           - KeyName
           - InboundClientCidr
           - InboundAdminCidr

--- a/marketplace.yaml
+++ b/marketplace.yaml
@@ -19,6 +19,9 @@ Parameters:
   DatabaseSubnets:
     Description: Provide a comma separated list of Subnet IDs for the Postgres database (Leave blank to use the ServerSubnets specified above)
     Type: CommaDelimitedList
+  ElasticSearchSubnets:
+    Description: Provide a comma separated list of Subnet IDs for the ElasticSearch cluster (Leave blank to use the ServerSubnets specified above)
+    Type: CommaDelimitedList
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
     Type: AWS::EC2::KeyPair::KeyName
@@ -206,6 +209,8 @@ Conditions:
     !Equals [ !Select [ 0, !Ref LoadBalancerSubnets], '' ]
   UseServerSubnetsForDatabase:
     !Equals [ !Select [ 0, !Ref DatabaseSubnets], '' ]
+  UseServerSubnetsForElasticSearch:
+    !Equals [ !Select [ 0, !Ref ElasticSearchSubnets], '' ]
 
 Metadata:
   cfn-lint:
@@ -519,6 +524,7 @@ Resources:
         ElasticSearchVersion: !Ref ChefElasticSearchVersion
         ElasticSearchShardCount: !Ref ChefElasticSearchShardCount
         ElasticSearchReplicaCount: !If [2ZoneES, 1, 2]
+        ElasticSearchSubnets: !If [UseServerSubnetsForElasticSearch, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref ElasticSearchSubnets ] ]
         LoadBalancerScheme: !Ref LoadBalancerScheme
         LoadBalancerSecurityGroupId: !Ref LoadBalancerSecurityGroup
         LoadBalancerSubnets: !If [UseServerSubnetsForLoadBalancers, !Join [ ",", !Ref ServerSubnets ], !Join [ ",", !Ref LoadBalancerSubnets ] ]

--- a/supermarket.yaml
+++ b/supermarket.yaml
@@ -7,8 +7,8 @@ Parameters:
     Description: Choose VPC to use
     Type: AWS::EC2::VPC::Id
   LoadBalancerSubnets:
-    Description: Provide a comma separated list of Subnet IDs for the Chef Servers (must be at least 2 within the specified VPC)
-    Type: CommaDelimitedList
+    Description: Provide a list of Subnet IDs for the Chef Servers (must be at least 2 within the specified VPC)
+    Type: List<AWS::EC2::Subnet::Id>
   SupermarketSubnet:
     Description: Provide a single Subnet ID for the Supermarket Server (must be within the specified VPC)
     Type: AWS::EC2::Subnet::Id

--- a/supermarket.yaml
+++ b/supermarket.yaml
@@ -7,8 +7,8 @@ Parameters:
     Description: Choose VPC to use
     Type: AWS::EC2::VPC::Id
   LoadBalancerSubnets:
-    Description: Provide a list of Subnet IDs for the Chef Servers (must be at least 2 within the specified VPC)
-    Type: List<AWS::EC2::Subnet::Id>
+    Description: Provide a comma separated list of Subnet IDs for the Chef Servers (must be at least 2 within the specified VPC)
+    Type: CommaDelimitedList
   SupermarketSubnet:
     Description: Provide a single Subnet ID for the Supermarket Server (must be within the specified VPC)
     Type: AWS::EC2::Subnet::Id


### PR DESCRIPTION
These changes add additional parameters to the necessary templates to allow specifying different subnets for the ELBs and/or the database.  If the parameters are left empty the original behavior of using the ServerSubnets for all resources is maintained.

These parameters must be added as type `CommaDelimitedList` because it is not possible to leave AWS-specific parameters like `List<AWS::EC2::Subnet::Id>` blank.

This change also removes the `UsePublicIp` condition and the associated logic in the Outputs section from `automate.yaml`.  This logic seems unnecessary since even when using the `internet-facing` ELB scheme, the Automate instance itself will never have a public IP address (and the logic actually fails when `internet-facing` is specified since there is no public IP address on the EC2 instance to retrieve).  The `AssociatePublicIpAddress` parameter in main.yaml is not passed to automate.yaml and the Automate EC2 resource does not include any configuration for using a public IP.  