### PR TITLE
Add custom config parameter to main.yaml

### DIFF
--- a/main.yaml
+++ b/main.yaml
@@ -74,6 +74,10 @@ Parameters:
     MaxValue: 16000
   ###############################################################################
   # Chef Server Stack Settings
+  ChefServerCustomConfig:
+    Default: ''
+    Type: String
+    Description: The S3 location of a custom chef-server configuration snippet that will be injected into the chef-server.rb (optional)
   ChefSSLCertificateARN:
     Description: ARN for SSL Certficate, pre-create this in AWS Certificate Manager
     Type: String
@@ -249,6 +253,7 @@ Metadata:
       - Label:
           default: "Chef Server Settings"
         Parameters:
+          - ChefServerCustomConfig
           - ChefServerDnsRecordName
           - ChefInstanceType
           - ChefDBInstanceClass
@@ -539,6 +544,7 @@ Resources:
         FrontendSecurityGroupId: !If [CreateFrontendSecurityGroup, !Ref FrontendSecurityGroup, !Ref FrontendSecurityGroupId]
         ChefServerAssociatePublicIpAddress: !Ref AssociatePublicIpAddress
         ChefServerIamRole: !If [CreateChefIamRole, !Ref ChefRole, !Ref ExistingIamRole]
+        ChefServerCustomConfig: !Ref ChefServerCustomConfig
         ChefSecretsBucket: !If [CreateChefSecretsBucket, !Ref ChefBucket, !Ref ExistingSecretsBucket]
         ChefAutomateServerUrl: !Sub "https://${AutomateStack.Outputs.DNSName}"
         ChefAutomateToken: !Ref ChefAutomateToken

--- a/main.yaml
+++ b/main.yaml
@@ -74,10 +74,6 @@ Parameters:
     MaxValue: 16000
   ###############################################################################
   # Chef Server Stack Settings
-  ChefServerCustomConfig:
-    Default: ''
-    Type: String
-    Description: The S3 location of a custom chef-server configuration snippet that will be injected into the chef-server.rb (optional)
   ChefSSLCertificateARN:
     Description: ARN for SSL Certficate, pre-create this in AWS Certificate Manager
     Type: String
@@ -149,6 +145,10 @@ Parameters:
     Type: Number
     MinValue: 2
     MaxValue: 3
+  ChefServerCustomConfig:
+    Default: ''
+    Type: String
+    Description: The S3 location of a custom chef-server configuration snippet that will be injected into the chef-server.rb (optional)
   ###############################################################################
   # Automate Stack Settings
   SupermarketSSLCertificateARN:
@@ -253,7 +253,6 @@ Metadata:
       - Label:
           default: "Chef Server Settings"
         Parameters:
-          - ChefServerCustomConfig
           - ChefServerDnsRecordName
           - ChefInstanceType
           - ChefDBInstanceClass
@@ -264,6 +263,7 @@ Metadata:
           - ChefElasticSearchInstanceType
           - ChefElasticSearchVersion
           - ChefElasticSearchShardCount
+          - ChefServerCustomConfig
       - Label:
           default: "Supermarket Settings"
         Parameters:


### PR DESCRIPTION
The chef_server_ha.yaml template already has code in it to allow custom chef-server.rb config items to be appended to the default chef-server.rb config file.  This parameter was not exposed in main.yaml though and could not be used in a complete stack.